### PR TITLE
Offline support of GW board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 hs_*.log
 bin/
 Gemfile.lock
+bower_components
 *.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -11,18 +11,20 @@ git clone https://github.com/mumuki/mumuki-gobstones-runner
 cd mumuki-gobstones-runner
 ```
 
-## Install Ruby
+## Install Ruby and Bower
 
 ```bash
 rbenv install 2.3.1
 rbenv rehash
 gem install bundler
+npm install -g bower
 ```
 
 ## Install Dependencies
 
 ```bash
 bundle install
+bower install
 ```
 
 # Run tests

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "mumuki-gobstones-runner",
+  "homepage": "https://github.com/mumuki/mumuki-gobstones-runner",
+  "authors": [
+    "Rodrigo Alfonso <rodri042@gmail.com>"
+  ],
+  "description": "",
+  "main": "",
+  "license": "MIT",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "gs-board": "gobstones/gs-board#^1.1.5",
+    "webcomponentsjs": "^0.7.23"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "tests"
   ],
   "dependencies": {
-    "gs-board": "gobstones/gs-board#^1.1.5",
+    "gs-board": "gobstones/gs-board#^1.1.9",
     "webcomponentsjs": "^0.7.23"
   }
 }

--- a/lib/boards.html.erb
+++ b/lib/boards.html.erb
@@ -10,7 +10,7 @@
     return array;
   }
 
-  function insertAndExecute(html) {
+  function dynamicLoad(html) {
     var element = document.createElement("div");
     element.innerHTML = html;
 
@@ -23,10 +23,10 @@
       element.getElementsByTagName("script")
     ).filter(function(it) {
       return !it.type || it.type.toLowerCase === "text/javascript";
-    }).forEach(evalScript);
+    }).forEach(evalScriptNode);
   }
 
-  function evalScript(son) {
+  function evalScriptNode(son) {
     // Clone the <script> dom element
     var code = son.text || son.textContent || son.innerHTML || "";
     var newSon = document.createElement("script");
@@ -39,11 +39,15 @@
     father.insertBefore(newSon, father.childNodes[position]);
   }
 
-  if (!window.GS_BOARD_LOADED) {
-    var boardCode = atob('<%= @board_code %>');
-    insertAndExecute(boardCode);
-    window.GS_BOARD_LOADED = true;
+  function loadIfNotLoaded(flag, base64) {
+    if (!window[flag]) {
+      dynamicLoad(atob(base64));
+      window[flag] = true;
+    }
   }
+
+  loadIfNotLoaded("POLYMER_1_LOADED", '<%= @polymer_code %>');
+  loadIfNotLoaded("GS_BOARD_LOADED", '<%= @board_code %>');
 </script>
 
 <style>

--- a/lib/boards.html.erb
+++ b/lib/boards.html.erb
@@ -2,18 +2,47 @@
   <%= File.read("bower_components/webcomponentsjs/webcomponents.min.js") %>
 </script>
 
-<script type="text/template" id="board-code">
-  <%= File.read("bower_components/gs-board/dist/out.html") %>
-</script>
-
 <script>
-  if (!window.GS_BOARD_LOADED) {
-    window.GS_BOARD_LOADED = true;
-    var boardCode = document.getElementById("board-code").innerHTML;
+  function toArray(obj) {
+    var array = [];
+    for (var i = obj.length >>> 0; i--;)
+      array[i] = obj[i];
+    return array;
+  }
 
+  function insertAndExecute(html) {
     var element = document.createElement("div");
-    element.innerHTML = boardCode;
-    document.body.insertBefore(element, document.body.childNodes[0]);
+    element.innerHTML = html;
+
+    // Insert the html on the document
+    var firstChild = document.body.childNodes[0];
+    document.body.insertBefore(element, firstChild);
+
+    // Recursively force the execution of <script> tags
+    toArray(
+      element.getElementsByTagName("script")
+    ).filter(function(it) {
+      return !it.type || it.type.toLowerCase === "text/javascript";
+    }).forEach(evalScript);
+  }
+
+  function evalScript(son) {
+    // Clone the <script> dom element
+    var code = son.text || son.textContent || son.innerHTML || "";
+    var newSon = document.createElement("script");
+    newSon.innerHTML = code;
+
+    // Reinsert to the dom to force the browser to execute it
+    var father = son.parentNode;
+    var position = toArray(father.childNodes).indexOf(son);
+    father.removeChild(son);
+    father.insertBefore(newSon, father.childNodes[position]);
+  }
+
+  if (!window.GS_BOARD_LOADED) {
+    var boardCode = atob('<%= @board_code %>');
+    insertAndExecute(boardCode);
+    window.GS_BOARD_LOADED = true;
   }
 </script>
 

--- a/lib/boards.html.erb
+++ b/lib/boards.html.erb
@@ -1,7 +1,8 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.23/webcomponents.min.js"></script>
-<link href="https://cdn.rawgit.com/download/polymer-cdn/1.2.3.2/lib/polymer/polymer.html" rel="import">
-<link rel="import" href="https://raw.githubusercontent.com/gobstones/gs-board/master/dist/components/gs-board.html"></link>
-<!-- // TODO: Esto no funciona offline. Compilar todo en un solo archivo con vulcanize y embeberlo. Ver por qué así como está no carga el svg de las bolitas. -->
+<script>
+  <%= File.read("public/bower_components/webcomponentsjs/webcomponents.min.js") %>
+</script>
+
+<%= File.read("public/bower_components/gs-board/dist/out.html") %>
 
 <style>
 

--- a/lib/boards.html.erb
+++ b/lib/boards.html.erb
@@ -3,49 +3,10 @@
 </script>
 
 <script>
-  function toArray(obj) {
-    var array = [];
-    for (var i = obj.length >>> 0; i--;)
-      array[i] = obj[i];
-    return array;
-  }
+  <%= File.read("lib/dynamic_load_html.js") %>
+</script>
 
-  function dynamicLoad(html) {
-    var element = document.createElement("div");
-    element.innerHTML = html;
-
-    // Insert the html on the document
-    var firstChild = document.body.childNodes[0];
-    document.body.insertBefore(element, firstChild);
-
-    // Recursively force the execution of <script> tags
-    toArray(
-      element.getElementsByTagName("script")
-    ).filter(function(it) {
-      return !it.type || it.type.toLowerCase === "text/javascript";
-    }).forEach(evalScriptNode);
-  }
-
-  function evalScriptNode(son) {
-    // Clone the <script> dom element
-    var code = son.text || son.textContent || son.innerHTML || "";
-    var newSon = document.createElement("script");
-    newSon.innerHTML = code;
-
-    // Reinsert to the dom to force the browser to execute it
-    var father = son.parentNode;
-    var position = toArray(father.childNodes).indexOf(son);
-    father.removeChild(son);
-    father.insertBefore(newSon, father.childNodes[position]);
-  }
-
-  function loadIfNotLoaded(flag, base64) {
-    if (!window[flag]) {
-      dynamicLoad(atob(base64));
-      window[flag] = true;
-    }
-  }
-
+<script>
   loadIfNotLoaded("POLYMER_1_LOADED", '<%= @polymer_code %>');
   loadIfNotLoaded("GS_BOARD_LOADED", '<%= @board_code %>');
 </script>

--- a/lib/boards.html.erb
+++ b/lib/boards.html.erb
@@ -1,8 +1,21 @@
 <script>
-  <%= File.read("public/bower_components/webcomponentsjs/webcomponents.min.js") %>
+  <%= File.read("bower_components/webcomponentsjs/webcomponents.min.js") %>
 </script>
 
-<%= File.read("public/bower_components/gs-board/dist/out.html") %>
+<script type="text/template" id="board-code">
+  <%= File.read("bower_components/gs-board/dist/out.html") %>
+</script>
+
+<script>
+  if (!window.GS_BOARD_LOADED) {
+    window.GS_BOARD_LOADED = true;
+    var boardCode = document.getElementById("board-code").innerHTML;
+
+    var element = document.createElement("div");
+    element.innerHTML = boardCode;
+    document.body.insertBefore(element, document.body.childNodes[0]);
+  }
+</script>
 
 <style>
 

--- a/lib/dynamic_load_html.js
+++ b/lib/dynamic_load_html.js
@@ -1,0 +1,42 @@
+function loadIfNotLoaded(flag, base64) {
+  if (!window[flag]) {
+    dynamicLoad(atob(base64));
+    window[flag] = true;
+  }
+}
+
+function dynamicLoad(html) {
+  var element = document.createElement("div");
+  element.innerHTML = html;
+
+  // Insert the html on the document
+  var firstChild = document.body.childNodes[0];
+  document.body.insertBefore(element, firstChild);
+
+  // Recursively force the execution of <script> tags
+  toArray(
+    element.getElementsByTagName("script")
+  ).filter(function(it) {
+    return !it.type || it.type.toLowerCase === "text/javascript";
+  }).forEach(evalScriptNode);
+}
+
+function evalScriptNode(son) {
+  // Clone the <script> dom element
+  var code = son.text || son.textContent || son.innerHTML || "";
+  var newSon = document.createElement("script");
+  newSon.innerHTML = code;
+
+  // Reinsert to the dom to force the browser to execute it
+  var father = son.parentNode;
+  var position = toArray(father.childNodes).indexOf(son);
+  father.removeChild(son);
+  father.insertBefore(newSon, father.childNodes[position]);
+}
+
+function toArray(obj) {
+  var array = [];
+  for (var i = obj.length >>> 0; i--;)
+    array[i] = obj[i];
+  return array;
+}

--- a/lib/html_renderer.rb
+++ b/lib/html_renderer.rb
@@ -1,7 +1,10 @@
+require "base64"
+
 module Gobstones
   class HtmlRenderer
     def initialize(options)
       @options = options
+      @board_code = Base64.strict_encode64(File.read("bower_components/gs-board/dist/out.html"))
     end
 
     def render_success(result)

--- a/lib/html_renderer.rb
+++ b/lib/html_renderer.rb
@@ -4,7 +4,8 @@ module Gobstones
   class HtmlRenderer
     def initialize(options)
       @options = options
-      @board_code = Base64.strict_encode64(File.read("bower_components/gs-board/dist/out.html"))
+      @polymer_code = encode_board_html "polymer"
+      @board_code = encode_board_html "gs-board"
     end
 
     def render_success(result)
@@ -73,6 +74,10 @@ module Gobstones
         table: JSON.generate(board[:table][:json]),
         boom: boom
       }
+    end
+
+    def encode_board_html(file_name)
+      Base64.strict_encode64 File.read("bower_components/gs-board/dist/#{file_name}.html")
     end
 
     def bind_result(result)


### PR DESCRIPTION
Now the runner returns in the output all the necessary things to work. The `dynamic_load_html.js` file does what a html import would do if there's no internet connection (meh). Really, the html import guarantees idempotency (it won't add the html or execute the scripts twice) and I've to add a few flags for the cases when the code is already loaded on Atheneum (i.e. the student runs an exercise for second time).

The polymer code is minified and all that thing. Later we can view pros and cons of including the Polymer 1.x framework on Atheneum so the student don't have to download it each time he runs an exercise (~250kb) and remove it from here. 