### PR TITLE
Failing spec - Fixes #19 - Fixes #21

### DIFF
--- a/lib/checker.rb
+++ b/lib/checker.rb
@@ -10,11 +10,11 @@ module Gobstones
       status = output[:status]
       result = output[:result]
 
-      is_timeout_and_nobody_cares = result[:finalBoardError] &&
+      is_expected_timeout = result[:finalBoardError] &&
                                     result[:finalBoardError][:reason][:code] == 'timeout' &&
                                     @options[:expect_endless_while]
 
-      return if is_timeout_and_nobody_cares
+      return if is_expected_timeout
       assert_not_boom status, result
 
       expected_board = result[:extraBoard]

--- a/lib/checker.rb
+++ b/lib/checker.rb
@@ -10,6 +10,11 @@ module Gobstones
       status = output[:status]
       result = output[:result]
 
+      is_timeout_and_nobody_cares = result[:finalBoardError] &&
+                                    result[:finalBoardError][:reason][:code] == 'timeout' &&
+                                    @options[:expect_endless_while]
+
+      return if is_timeout_and_nobody_cares
       assert_not_boom status, result
 
       expected_board = result[:extraBoard]
@@ -49,20 +54,21 @@ module Gobstones
       result = output[:result]
 
       assert_not_boom status, result
-      value = result[:finalBoard][:returnValue]
+      return_value = result[:finalBoard][:returnValue]
 
       fail_with status: :check_return_failed_no_return,
                 result: {
                   initial: result[:initialBoard],
                   expected_value: expected
-                } if value.nil?
+                } if return_value.nil?
 
+      final_value = return_value[:value]
       fail_with status: :check_return_failed_different_values,
                 result: {
                   initial: result[:initialBoard],
                   expected_value: expected,
-                  actual_value: value
-                } if value != expected
+                  actual_value: final_value
+                } if final_value != expected
     end
 
     private

--- a/lib/gobstones/batch_parser.rb
+++ b/lib/gobstones/batch_parser.rb
@@ -44,6 +44,7 @@ module Gobstones::BatchParser
         struct(key: :show_initial_board, default: true),
         struct(key: :show_final_board, default: true),
         struct(key: :check_head_position, default: false),
+        struct(key: :expect_endless_while, default: false),
         struct(key: :subject, default: nil)
       ].map { |it| [
           it.key,

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -45,8 +45,6 @@ program {
   end
 
   it 'answers a valid hash when submission passes, in gobstones' do
-    # // TODO: Use the old mulang syntax
-
     response = bridge.run_tests!(
       content: '
 procedure PonerUnaDeCada() {
@@ -57,9 +55,9 @@ procedure PonerUnaDeCada() {
 }',
       extra: '',
       expectations: [
-        {binding: 'program', inspection: 'Uses:PonerUnaDeCada'},
-        {binding: '*', inspection: 'Not:Declares:program'},
-        {binding: '*', inspection: 'Declares:PonerUnaDeCada'}
+        {binding: 'program', inspection: 'HasUsage:PonerUnaDecada'},
+        {binding: 'program', inspection: 'Not:HasBinding'},
+        {binding: 'PonerUnaDeCada', inspection: 'HasBinding'}
       ],
       test: '
 check_head_position: true
@@ -91,48 +89,48 @@ examples:
                                                  status: :passed_with_warnings,
                                                  feedback: '',
                                                  expectation_results: [
-                                                   {binding: 'program', inspection: 'Uses:PonerUnaDeCada', result: :failed},
-                                                   {binding: '*', inspection: 'Not:Declares:program', result: :passed},
-                                                   {binding: '*', inspection: 'Declares:PonerUnaDeCada', result: :passed}],
+                                                   {binding: "program", inspection: "Uses:=PonerUnaDecada", result: :failed},
+                                                   {binding: "*", inspection: "Not:Declares:=program", result: :passed},
+                                                   {binding: "*", inspection: "Declares:=PonerUnaDeCada", result: :passed}
+                                                 ],
                                                  result: ''
     expect(response[:test_results].size).to eq 2
   end
 
-# // TODO: Use the old mulang syntax, swapping binding and target.
-# // TODO: Another problem is that currently "Declares:HastaElInfinite" is converted to "Declares"
-#   it 'answers a valid hash when submission is aborted and expected, in gobstones' do
-#     response = bridge.run_tests!(
-#       language: :gobstones,
-#       content: '
-# procedure HastaElInfinito() {
-#   while (puedeMover(Este)) {
-#     Poner(Rojo)
-#   }
-# }',
-#       extra: '',
-#       expectations: [
-#         {:binding=>"*", :inspection=>"Not:Declares:program"},
-#         {:binding=>"*", :inspection=>"Declares:HastaElInfinito"}
-#       ],
-#       test: '
-# subject: HastaElInfinito
-# expect_endless_while: true
-# examples:
-#  - initial_board: |
-#      GBB/1.0
-#      size 2 2
-#      head 0 0
-#    final_board: |
-#      GBB/1.0
-#      size 2 2
-#      head 0 0')
-#
-#     expect(response.except(:test_results)).to eq response_type: :structured,
-#                                                  status: :passed,
-#                                                  feedback: '',
-#                                                  expectation_results: [
-#                                                    {:binding=>"*", :inspection=>"Not:Declares:program", :result=>:passed},
-#                                                    {:binding=>"*", :inspection=>"Declares:HastaElInfinito", :result=>:passed}],
-#                                                  result: ''
-#   end
+  it 'answers a valid hash when submission is aborted and expected, in gobstones' do
+    response = bridge.run_tests!(
+      language: :gobstones,
+      content: '
+procedure HastaElInfinito() {
+  while (puedeMover(Este)) {
+    Poner(Rojo)
+  }
+}',
+      extra: '',
+      expectations: [
+        {binding: "program", inspection: "Not:HasBinding"},
+        {binding: "HastaElInfinito", inspection: "HasBinding"}
+      ],
+      test: '
+subject: HastaElInfinito
+expect_endless_while: true
+examples:
+ - initial_board: |
+     GBB/1.0
+     size 2 2
+     head 0 0
+   final_board: |
+     GBB/1.0
+     size 2 2
+     head 0 0')
+
+    expect(response.except(:test_results)).to eq response_type: :structured,
+                                                 status: :passed,
+                                                 feedback: '',
+                                                 expectation_results: [
+                                                   {binding: "*", inspection: "Not:Declares:=program", result: :passed},
+                                                   {binding: "*", inspection: "Declares:=HastaElInfinito", result: :passed}
+                                                 ],
+                                                 result: ''
+  end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -45,6 +45,8 @@ program {
   end
 
   it 'answers a valid hash when submission passes, in gobstones' do
+    # // TODO: Use the old mulang syntax
+
     response = bridge.run_tests!(
       content: '
 procedure PonerUnaDeCada() {
@@ -96,4 +98,41 @@ examples:
     expect(response[:test_results].size).to eq 2
   end
 
+# // TODO: Use the old mulang syntax, swapping binding and target.
+# // TODO: Another problem is that currently "Declares:HastaElInfinite" is converted to "Declares"
+#   it 'answers a valid hash when submission is aborted and expected, in gobstones' do
+#     response = bridge.run_tests!(
+#       language: :gobstones,
+#       content: '
+# procedure HastaElInfinito() {
+#   while (puedeMover(Este)) {
+#     Poner(Rojo)
+#   }
+# }',
+#       extra: '',
+#       expectations: [
+#         {:binding=>"*", :inspection=>"Not:Declares:program"},
+#         {:binding=>"*", :inspection=>"Declares:HastaElInfinito"}
+#       ],
+#       test: '
+# subject: HastaElInfinito
+# expect_endless_while: true
+# examples:
+#  - initial_board: |
+#      GBB/1.0
+#      size 2 2
+#      head 0 0
+#    final_board: |
+#      GBB/1.0
+#      size 2 2
+#      head 0 0')
+#
+#     expect(response.except(:test_results)).to eq response_type: :structured,
+#                                                  status: :passed,
+#                                                  feedback: '',
+#                                                  expectation_results: [
+#                                                    {:binding=>"*", :inspection=>"Not:Declares:program", :result=>:passed},
+#                                                    {:binding=>"*", :inspection=>"Declares:HastaElInfinito", :result=>:passed}],
+#                                                  result: ''
+#   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -44,4 +44,52 @@ program {
     expect(response[:response_type]).to eq :structured
   end
 
+  it 'answers a valid hash when submission passes, in gobstones' do
+    response = bridge.run_tests!(
+      content: '
+procedure PonerUnaDeCada() {
+    Poner (Rojo)
+    Poner (Azul)
+    Poner (Negro)
+    Poner (Verde)
+}',
+      extra: '',
+      expectations: [{binding: 'PonerUnaDeCada', inspection: 'HasUsage'}],
+      test: '
+check_head_position: true
+
+subject: PonerUnaDeCada
+
+examples:
+ - initial_board: |
+     GBB/1.0
+     size 4 4
+     head 0 0
+   final_board: |
+     GBB/1.0
+     size 4 4
+     cell 0 0 Azul 1 Rojo 1 Verde 1 Negro 1
+     head 0 0
+
+ - initial_board: |
+     GBB/1.0
+     size 5 5
+     head 3 3
+   final_board: |
+     GBB/1.0
+     size 5 5
+     cell 3 3 Azul 1 Rojo 1 Verde 1 Negro 1
+     head 3 3')
+
+    expect(response.except(:test_results)).to eq response_type: :structured,
+                                                 status: :passed,
+                                                 feedback: '',
+                                                 expectation_results: [
+                                                   {binding: 'PonerUnaDeCada', inspection: 'HasUsage', result: :passed}, # Should be failed
+                                                   {binding: 'program', inspection: 'Not:HasBinding', result: :passed},
+                                                   {binding: 'PonerUnaDeCada', inspection: 'HasBinding', result: :passed}],
+                                                 result: ''
+    expect(response[:test_results].size).to eq 2
+  end
+
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -54,7 +54,11 @@ procedure PonerUnaDeCada() {
     Poner (Verde)
 }',
       extra: '',
-      expectations: [{binding: 'PonerUnaDeCada', inspection: 'HasUsage'}],
+      expectations: [
+        {binding: 'program', inspection: 'Uses:PonerUnaDeCada'},
+        {binding: '*', inspection: 'Not:Declares:program'},
+        {binding: '*', inspection: 'Declares:PonerUnaDeCada'}
+      ],
       test: '
 check_head_position: true
 
@@ -82,12 +86,12 @@ examples:
      head 3 3')
 
     expect(response.except(:test_results)).to eq response_type: :structured,
-                                                 status: :passed,
+                                                 status: :passed_with_warnings,
                                                  feedback: '',
                                                  expectation_results: [
-                                                   {binding: 'PonerUnaDeCada', inspection: 'HasUsage', result: :passed}, # Should be failed
-                                                   {binding: 'program', inspection: 'Not:HasBinding', result: :passed},
-                                                   {binding: 'PonerUnaDeCada', inspection: 'HasBinding', result: :passed}],
+                                                   {binding: 'program', inspection: 'Uses:PonerUnaDeCada', result: :failed},
+                                                   {binding: '*', inspection: 'Not:Declares:program', result: :passed},
+                                                   {binding: '*', inspection: 'Declares:PonerUnaDeCada', result: :passed}],
                                                  result: ''
     expect(response[:test_results].size).to eq 2
   end

--- a/spec/metatest_spec.rb
+++ b/spec/metatest_spec.rb
@@ -16,7 +16,7 @@ describe 'metatest' do
   let(:dummy_gbb) do
     'GBB/1.0\r\nsize 1 1\r\nhead 0 0\r\n'
   end
-  let(:exit_status) { 29 }
+  let(:exit_status) { { type: "Number", value: 29 } }
   let(:compilation_boom) do
     [
       {

--- a/spec/test_runner_spec.rb
+++ b/spec/test_runner_spec.rb
@@ -29,6 +29,7 @@ EOF
     let(:test) {
 %q{
 check_head_position: true
+expect_endless_while: true
 examples:
 - title: A name
   initial_board: |
@@ -81,6 +82,7 @@ examples:
       it { expect(runner.batch.options).to eq show_initial_board: true,
                                         show_final_board: true,
                                         check_head_position: true,
+                                        expect_endless_while: true,
                                         subject: nil }
       it { expect(runner.batch.examples).to eq expected_examples }
     end
@@ -116,6 +118,7 @@ examples:
         show_initial_board: true,
         show_final_board: false,
         check_head_position: false,
+        expect_endless_while: false,
         subject: "aName"
       }) }
       it { expect(runner.batch.examples).to eq expected_examples }


### PR DESCRIPTION
@flbulgarelli I've been testing and now I can confirm that the test was wrong. Maybe it was working accidentally using a previous version of `mumukit-inspection`

For the code:
```
procedure PonerUnaDeCada() {
    Poner (Rojo)
    Poner (Azul)
    Poner (Negro)
    Poner (Verde)
}
```

The expectation:
```js
{  binding: 'PonerUnaDeCada', inspection: 'HasUsage' }
```
caused the bug.

[All the guide exercises](https://github.com/search?q=org%3Asagrado-corazon-alcal+HasUsage&type=Code) use this other form:
```js
{ binding: 'program', inspection: 'HasUsage:PonerUnaDeCada' }
```

---

I think the only case where the binding and target are inverted is `HasBinding` and `mumukit-inspection` is already handling it. So I only needed to update the tests assertions because now the results are given with the new format.

---

I also found a bug in the return value checker and fixed it.