### PR TITLE
Defining a local wrapper for gs-element-blockly and updating editor.js

### DIFF
--- a/lib/assets_server.rb
+++ b/lib/assets_server.rb
@@ -27,11 +27,12 @@ class Mumukit::Server::App < Sinatra::Base
     get_asset route, File.join(__dir__, '..' , path), type
   end
 
-  get_local_asset  'editor/editor.js',     'lib/render/editor/editor.js',               'application/javascript'
-  get_board_asset  'polymer.html',         'htmls/vendor/polymer.html',                 'text/html'
-  get_board_asset  'polymer-mini.html',    'htmls/vendor/polymer-mini.html',            'text/html'
-  get_board_asset  'polymer-micro.html',   'htmls/vendor/polymer-micro.html',           'text/html'
-  get_board_asset  'gs-board.html',        'htmls/gs-board.html',                       'text/html'
-  get_editor_asset 'editor/editor.html',   'htmls/gs-element-blockly.html',             'text/html'
-  get_local_asset  'editor/editor.css',    'lib/render/editor/editor.css',              'text/css'
+  get_local_asset  'editor/editor.js',                'lib/render/editor/editor.js',               'application/javascript'
+  get_board_asset  'polymer.html',                    'htmls/vendor/polymer.html',                 'text/html'
+  get_board_asset  'polymer-mini.html',               'htmls/vendor/polymer-mini.html',            'text/html'
+  get_board_asset  'polymer-micro.html',              'htmls/vendor/polymer-micro.html',           'text/html'
+  get_board_asset  'gs-board.html',                   'htmls/gs-board.html',                       'text/html'
+  get_editor_asset 'editor/gs-element-blockly.html',  'htmls/gs-element-blockly.html',             'text/html'
+  get_local_asset  'editor/editor.css',               'lib/render/editor/editor.css',              'text/css'
+  get_local_asset  'editor/editor.html',              'lib/render/editor/editor.html',             'text/html'
 end

--- a/lib/render/editor/editor.html
+++ b/lib/render/editor/editor.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+<head>
+  <!-- blockly -->
+  <link href="./gs-element-blockly.html" rel="import" />
+</head>
+
+<body>
+
+<dom-module id="blockly-container">
+  <template>
+    <gs-element-blockly id="blocklyElement"></gs-element-blockly>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'blockly-container',
+      ready: function() {
+        setTimeout(() => {
+          this.$.blocklyElement.workspace.addChangeListener(() => {
+            $("#custom-editor-value")[0].value = this.$.blocklyElement.generateCode();
+          });
+        });
+      }
+    });
+  </script>
+</dom-module>
+
+<blockly-container></blockly-container>
+
+</body>
+</html>

--- a/lib/render/editor/editor.html
+++ b/lib/render/editor/editor.html
@@ -1,11 +1,4 @@
-<!doctype html>
-<html>
-<head>
-  <!-- blockly -->
-  <link href="./gs-element-blockly.html" rel="import" />
-</head>
-
-<body>
+<link href="./gs-element-blockly.html" rel="import" />
 
 <dom-module id="blockly-container">
   <template>
@@ -26,7 +19,3 @@
   </script>
 </dom-module>
 
-<blockly-container></blockly-container>
-
-</body>
-</html>

--- a/lib/render/editor/editor.js
+++ b/lib/render/editor/editor.js
@@ -1,9 +1,3 @@
 $(document).ready(() => {
-  $("#custom-editor").html("<gs-element-blockly />");
-
-  const blockly = $("gs-element-blockly")[0];
-
-  blockly.workspace.addChangeListener(() => {
-    $("#custom-editor-value")[0].value = blockly.generateCode();
-  });
+  $("#custom-editor").html("<blockly-container />");
 });


### PR DESCRIPTION
@rodri042 I had to do the insertion in editor.js because otherwise it wasn't called again when navigating between pages