### PR TITLE
Fixing timeouts - Fixes #86

### DIFF
--- a/lib/gobstones_runner.rb
+++ b/lib/gobstones_runner.rb
@@ -5,7 +5,7 @@ I18n.load_translations_path File.join(__dir__, 'locales', '*.yml')
 
 Mumukit.runner_name = 'gobstones'
 Mumukit.configure do |config|
-  config.docker_image = 'mumuki/mumuki-gobstones-worker:1.8'
+  config.docker_image = 'mumuki/mumuki-gobstones-worker:1.9'
   config.content_type = 'html'
   config.structured = true
 end

--- a/lib/precompile_hook.rb
+++ b/lib/precompile_hook.rb
@@ -35,6 +35,6 @@ class GobstonesPrecompileHook < Mumukit::Templates::FileHook
   end
 
   def post_process_file(_file, result, status)
-    [result.parse_as_json, status]
+    [status == :passed ? result.parse_as_json : result, status]
   end
 end

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
 FROM node:6.10.3
 MAINTAINER Rodrigo Alfonso
 
-RUN npm install -g gobstones-cli@1.5.0
+RUN npm install -g gobstones-cli@1.6.0


### PR DESCRIPTION
Timeouts support was added in gobstones-cli @ https://github.com/gobstones/gobstones-cli/commit/362f84db932e5c69fcc98adf386950e2e758837d

This addresses two problems:
- Mumukit's timeouts were trying to be parsed as JSON (issue https://github.com/mumuki/mumuki-gobstones-runner/issues/86)
- The interpreter's timeouts were being treated as BOOMs (runtime errors).
![screenshot9](https://user-images.githubusercontent.com/1631752/38970470-0e7db980-436c-11e8-9df1-b9ee4a44bdb8.png)
