### PR TITLE
Use interpolated default content

### DIFF
--- a/lib/render/editor/editor.html
+++ b/lib/render/editor/editor.html
@@ -161,7 +161,7 @@
       },
 
       _setInitialXml: function (blockly) {
-        const editorDefaultContent = $("#mu-custom-editor-default-value")[0];
+        const editorDefaultContent = $("#default_content")[0];
         if (editorDefaultContent && editorDefaultContent.value) {
           blockly.initialXml = editorDefaultContent.value;
         } else {


### PR DESCRIPTION
Since we're going to remove the mu-custom-editor-default-value we should be completely sure that it is not being used anywhere else. A quick search turned up nothing.

Fixes mumuki/mumuki-laboratory#1057.