### PR TITLE
Updating gobstones components

### DIFF
--- a/lib/render/editor/editor.html
+++ b/lib/render/editor/editor.html
@@ -53,11 +53,16 @@
           // expressions
           Blockly.Msg.MATH_HUE = Blockly.MUMUKI_COLORS.blue;
           Blockly.CUSTOM_COLORS.literalExpression = Blockly.MUMUKI_COLORS.blue;
+          Blockly.CUSTOM_COLORS.primitiveExpression = Blockly.MUMUKI_COLORS.blue;
+          Blockly.CUSTOM_COLORS.operator = Blockly.MUMUKI_COLORS.blue;
           Blockly.CUSTOM_COLORS.variable = Blockly.MUMUKI_COLORS.blue;
           Blockly.CUSTOM_COLORS.parameter = Blockly.MUMUKI_COLORS.blue;
           Blockly.CUSTOM_COLORS.primitiveFunction = Blockly.MUMUKI_COLORS.blue;
           Blockly.CUSTOM_COLORS.function_call = Blockly.MUMUKI_COLORS.blue;
-          Blockly.CUSTOM_COLORS.expression = Blockly.MUMUKI_COLORS.blue;
+
+          setTimeout(() => {
+            this.getBlockly().testColors(Blockly.CUSTOM_COLORS);
+          });
         };
 
         const updateFields = () => {

--- a/mumuki-gobstones-runner.gemspec
+++ b/mumuki-gobstones-runner.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'mumukit', '~> 2.21'
   spec.add_dependency 'sinatra-cross_origin', '~> 0.4'
-  spec.add_dependency 'gobstones-board', '~>1.15'
-  spec.add_dependency 'gobstones-blockly', '~>0.12'
-  spec.add_dependency 'gobstones-code-runner', '~>0.2'
+  spec.add_dependency 'gobstones-board', '~>1.16'
+  spec.add_dependency 'gobstones-blockly', '~>0.14'
+  spec.add_dependency 'gobstones-code-runner', '~>0.3'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
This PR addresses some issues that @flbulgarelli found with kids layout.

Now teacher procedures are working now, the problem was that `gs-element-blockly` was doing some weird things to parse the custom toolbox (specifically, splitting the XML string by newlines and matching category blocks with regexps) and it wasn't working with `<category name="Procedimientos primitivos"></category>` instead of `<category name="Procedimientos primitivos">\n</category>`.

Regarding the colors, I added a few missing color mappings, and code for setting the colors on the first load (since the default code loads before applying the custom colors).

Updating `gobstones-board` and drawing a board without head worked for me :confused: 
I used this as an exercise's description: `"prueba sin header: <gs-board no-attire without-header>GBB/1.0\nsize 4 3\ncell 1 2 Azul 0 Negro 0 Rojo 8 Verde 0\ncell 3 2 Azul 2 Negro 0 Rojo 5 Verde 1\ncell 2 1 Azul 0 Negro 6 Rojo 0 Verde 0\nhead 1 2</gs-board>"`:
![selection_029](https://user-images.githubusercontent.com/1631752/40404107-541c6fae-5e56-11e8-9495-cac9f43df4d7.png)


