### PR TITLE
Checking expected timeouts on check_error too -  Fixes mumuki/mumuki-laboratory#1207

### DIFF
--- a/lib/checker.rb
+++ b/lib/checker.rb
@@ -10,11 +10,7 @@ module Gobstones
       status = output[:status]
       result = output[:result]
 
-      is_expected_timeout = result[:finalBoardError] &&
-                                    result[:finalBoardError][:reason][:code] == 'timeout' &&
-                                    @options[:expect_endless_while]
-
-      return if is_expected_timeout
+      return if is_expected_timeout(result)
       assert_not_boom status, result
 
       expected_board = result[:extraBoard]
@@ -39,6 +35,8 @@ module Gobstones
     def check_error(output, expected)
       status = output[:status]
       result = output[:result]
+
+      return if is_expected_timeout(result)
 
       fail_with status: :check_error_failed_expected_boom,
                 result: {
@@ -95,6 +93,12 @@ module Gobstones
                   actual: :boom,
                   reason: result[:finalBoardError]
                 } if status == :runtime_error
+    end
+
+    def is_expected_timeout(result)
+      result[:finalBoardError] &&
+      result[:finalBoardError][:reason][:code] == 'timeout' &&
+      @options[:expect_endless_while]
     end
 
     def fail_with(error)

--- a/lib/precompile_hook.rb
+++ b/lib/precompile_hook.rb
@@ -47,13 +47,17 @@ class GobstonesPrecompileHook < Mumukit::Templates::FileHook
   def post_process_file(_file, result, status)
     if status == :passed
       result = result.parse_as_json
-      status = :aborted if is_timeout? result and !@batch.options[:expect_endless_while]
+      status = :aborted if is_timeout? result and !expects_timeout?
     end
 
     [result, status]
   end
 
   private
+
+  def expects_timeout?
+    @batch.options[:expect_endless_while] || @batch.examples.any? { |it| it[:postconditions][:error] == 'timeout' }
+  end
 
   def is_timeout?(result)
     result[0]&.dig(:result, :finalBoardError, :reason, :code) === 'timeout'

--- a/lib/render/editor/editor.html
+++ b/lib/render/editor/editor.html
@@ -401,7 +401,6 @@
       },
 
       ready: function () {
-
         const resetStatusAfterAborted = () => {
           $('#kids-results-aborted').on('hidden.bs.modal', () => {
             this.$.runner.isDirty = false;


### PR DESCRIPTION
Fixes https://github.com/mumuki/mumuki-laboratory/issues/1207

Este PR es sobre los errores:

1) > Otro problema más raro aún es que en https://mumuki.io/primaria/exercises/5589-repeticion-condicional-practica-al-infinito, si se envíe el código tal cual está, da verde (pero debería fallar, porque falta un bloque)

Esto sucedía por varios problemas:
- gobstones-blockly generaba `while(not(())) { ... }` con el código en cuestión
- `()` es una tupla vacía en XGobstones
- `not` de una tupla vacía es un error en tiempo de ejecución, da boom
- El ejercicio tenía un solo `initial_board` pero ningún test, entonces no rompía. Si hubiera sido:
```
expect_endless_while: true
check_head_position: false
examples:
 - initial_board: |
     GBB/1.0
     size 2 2
     cell 0 1 Negro 4 Rojo 4 
     cell 1 1 Azul 6 Rojo 4 
     cell 0 0 Negro 4 Rojo 4 
     cell 1 0 Negro 4 Rojo 4 
     head 1 1
   final_board: |
     GBB/1.0
     size 2 2
     head 0 0
```
... habría funcionado.

Con este PR ahora también se puede hacer:
```
expect_endless_while: true
check_head_position: false
examples:
 - initial_board: |
     GBB/1.0
     size 2 2
     cell 0 1 Negro 4 Rojo 4 
     cell 1 1 Azul 6 Rojo 4 
     cell 0 0 Negro 4 Rojo 4 
     cell 1 0 Negro 4 Rojo 4 
     head 1 1
   error: "timeout"
```
...lo cual es más cortito y también aviva al runner de que hay un test que correr.

:warning: Mergear esto es un chiche nomás. Se puede hacerlo andar de la primera forma sin necesidad de hacer otro deploy.

2) > La UI se congela al correr un ejercicio con loops infinitos

Esto lo estuve viendo pero no es tan fácil, la forma de solucionarlo para mí es con Web Workers pero hay varios temas a solucionar:
- No pueden acceder al scope global, ni a ningún dato que no se pase mediante `.postMessage(...)` que solo admite datos planos y no objetos con comportamiento.
- Pueden importar scripts (en este caso el código del intérprete) pero solo mediante un [`importScripts`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts) que los baja de la red, y esto desde el runner se complica porque corren dentro de labo
- Habría que hacer un refactor grande en `gobstones-code-runner` para hacer el parseo e interpretación en el mismo paso y que la interfaz sea siempre asincrónica

Igualmente lo veo posible, pero es una tarea de varios días así que lo cargué en un issue aparte (https://github.com/mumuki/mumuki-gobstones-runner/issues/128)