### PR TITLE
Preventing invalid block ids

### DIFF
--- a/lib/render/editor/editor.html
+++ b/lib/render/editor/editor.html
@@ -106,6 +106,9 @@
           if (typeof Blockly === 'undefined' || !Blockly.CUSTOM_COLORS) return postpone(setBlocklyCustomSettings);
           setBlocklySounds();
           setBlocklyColors();
+
+          // Removing "/" from the block id character set to avoid syntax errors
+          Blockly.utils.genUid.soup_ = Blockly.utils.genUid.soup_.replace("/", "");
         };
 
         const updateFields = () => {


### PR DESCRIPTION
The problematic exercise was generating this code:

![bug](https://user-images.githubusercontent.com/1631752/53145396-ccd25a80-357e-11e9-825a-9a72fc0904b8.png)

(one of the instructions has an id that starts with `*/`, which closes the region pragma and causes a syntax error).

I've removed the `/` as a valid character for block ids so this can't happen again. The fix was applied in `gobstones-blockly` code as well, but since the last versions have some breaking changes, I decided not to update the component yet.

This won't make the problematic solutions work as they already have invalid block ids.