### PR TITLE
extracting gbb before initializing node

### DIFF
--- a/lib/render/editor/editor.html
+++ b/lib/render/editor/editor.html
@@ -543,12 +543,13 @@
       },
 
       _updateBoardFromResult: function (originalBoard, resultBoard) {
-        resultBoard = resultBoard.cloneNode(); // To force initialization
-        if (resultBoard.textContent) {
-          const boardAttrs = gbbReader.fromString(resultBoard.textContent);
-          originalBoard.update(boardAttrs.table, boardAttrs.header);
+        const resultGbb = resultBoard.textContent;
+        if (resultGbb) {
+          const boardAttrs = gbbReader.fromString(resultGbb);
+          originalBoard.update(boardAttrs.table, boardAttrs.head);
         }
         else {
+          resultBoard = resultBoard.cloneNode(); // To force initialization
           originalBoard.boom = resultBoard.boom;
         }
       },


### PR DESCRIPTION
This fixes the fact that the non-visible boards weren't being updated.