### PR TITLE
adding shows_loading_content for editor assets and calling onFinishLoading

### DIFF
--- a/lib/metadata_hook.rb
+++ b/lib/metadata_hook.rb
@@ -24,7 +24,8 @@ class GobstonesMetadataHook < Mumukit::Hook
         ],
         css: [
           'assets/editor/editor.css'
-        ]
+        ],
+        shows_loading_content: true
       },
       test_framework: {
         name: 'metatest',

--- a/lib/render/editor/editor.html
+++ b/lib/render/editor/editor.html
@@ -187,6 +187,9 @@
 
               this._subscribeToWorkspace(blockly, updateFields);
             });
+            if(mumuki.assetsLoader && !$('gs-toolbox').length) {
+              mumuki.assetsLoader.editor.onFinishLoading();
+            }
           });
         };
 
@@ -800,6 +803,7 @@
         $.get(this.toolboxUrl, function (toolboxXml) {
           blockly.toolbox = { defaultToolbox: toolboxXml };
           editor.setTeacherActions(blockly);
+          mumuki.assetsLoader && mumuki.assetsLoader.editor.onFinishLoading();
         });
       }
     });


### PR DESCRIPTION
I added it on a retrocompatible manner, so that this could work without the mumuki.assetsServer object.