### PR TITLE
Ensuring that mumuki.assetsLoadedFor is defined

### DIFF
--- a/lib/render/editor/editor.html
+++ b/lib/render/editor/editor.html
@@ -189,7 +189,7 @@
             });
 
             const hasCustomToolbox = $('gs-toolbox').length;
-            if(!hasCustomToolbox) mumuki.assetsLoadedFor('editor');
+            if(!hasCustomToolbox) this.enableContextButton();
           });
         };
 
@@ -227,6 +227,15 @@
             blockly.primitiveFunctions = actions.functionDeclarations;
           });
         }
+      },
+
+      enableContextButton() {
+        if(typeof mumuki !== "undefined" && mumuki.kids && mumuki.assetsLoadedFor) {
+          return mumuki.assetsLoadedFor('editor');
+        } else {
+          return postpone(this.enableContextButton.bind(this));
+        }
+
       },
 
       getBlockly: function () {
@@ -804,7 +813,7 @@
           blockly.toolbox = { defaultToolbox: toolboxXml };
           editor.setTeacherActions(blockly);
         }).always(function () {
-          mumuki.assetsLoadedFor('editor');
+          editor.enableContextButton();
         });
       }
     });
@@ -1020,7 +1029,7 @@
         if(this.configLoaded) this._createSwipeListener();
       },
       _createSwipeListener: function () {
-        if(typeof Hammer === "undefined") return postpone(this._createSwipeListener);
+        if(typeof Hammer === "undefined") return postpone(this._createSwipeListener.bind(this));
         const $swipeListenerArea = $('.mu-initial-state gs-board')[0];
         const hammer = new Hammer($swipeListenerArea);
         hammer.get('swipe').set({direction: Hammer.DIRECTION_ALL});
@@ -1057,7 +1066,7 @@
 
       _createKeyboardConfig: function () {
         if(typeof GobstonesKeyboard === 'undefined') GobstonesKeyboard = {};
-        if(typeof Hammer === "undefined") return postpone(this._createKeyboardConfig);
+        if(typeof Hammer === "undefined") return postpone(this._createKeyboardConfig.bind(this));
         GobstonesKeyboard.keyboardMap = {
           [Hammer.DIRECTION_LEFT]: 37,
           [Hammer.DIRECTION_UP]: 38,


### PR DESCRIPTION
In some weird cases, mumuki object isn't defined before that function is executed and the loader doesn't stop.