### PR TITLE
Removing board title

### DIFF
--- a/lib/checker.rb
+++ b/lib/checker.rb
@@ -49,7 +49,7 @@ module Gobstones
       fail_with status: :check_error_failed_another_reason,
                 result: {
                   reason: result[:finalBoardError],
-                  expected_code: expected
+                  expected_code: I18n.t("code_#{expected}")
                 } if reason_code != expected
     end
 

--- a/lib/render/boards.html.erb
+++ b/lib/render/boards.html.erb
@@ -4,6 +4,10 @@
     display: inline-flex;
   }
 
+  .results-list .boards-container {
+    margin: 20px 10px 30px;
+  }
+
   .error-text {
     color: #d9534f;
   }

--- a/lib/render/boards.html.erb
+++ b/lib/render/boards.html.erb
@@ -25,12 +25,6 @@
 
 </style>
 
-<% if @result[:error] %>
-  <p class="error-text">
-    <%=I18n.t @result[:error], @result %>
-  </p>
-<% end %>
-
 <div class="boards-container">
 
   <% @result[:boards].each do |it| %>

--- a/lib/render/html_renderer.rb
+++ b/lib/render/html_renderer.rb
@@ -49,7 +49,7 @@ module Gobstones
 
     def render_error_check_error_failed_another_reason(result)
       bind_result error: :check_error_failed_another_reason,
-                  expected_code: I18n.t("code_#{result[:expected_code]}"),
+                  expected_code: result[:expected_code],
                   reason: prepare_reason(result[:reason])
     end
 

--- a/spec/metatest_spec.rb
+++ b/spec/metatest_spec.rb
@@ -112,7 +112,7 @@ describe 'metatest' do
         }
 
         it { expect(result[0][0]).to include :failed }
-        it { expect(result[0][0][2]).to include "head doesn't match" }
+        it { expect(result[0][0][3][:message]).to include "head doesn't match" }
       end
 
       context 'when fails by different boards (stones)' do
@@ -121,7 +121,7 @@ describe 'metatest' do
         }
 
         it { expect(result[0][0]).to include :failed }
-        it { expect(result[0][0][2]).to include "different board was obtained" }
+        it { expect(result[0][0][3][:message]).to include "different board was obtained" }
       end
 
     end
@@ -130,7 +130,7 @@ describe 'metatest' do
       let(:compilation) { compilation_boom }
 
       it { expect(result[0][0]).to include :failed }
-      it { expect(result[0][0][2]).to include "The program did BOOM." }
+      it { expect(result[0][0][3][:message]).to include "The program did BOOM." }
     end
 
   end
@@ -150,7 +150,7 @@ describe 'metatest' do
       let(:compilation) { compilation_board }
 
       it { expect(result[0][0]).to include :failed }
-      it { expect(result[0][0][2]).to include "The program was expected to BOOM but a final board was obtained." }
+      it { expect(result[0][0][3][:message]).to include "The program was expected to BOOM but a final board was obtained." }
     end
 
     context 'when the program does boom' do
@@ -171,7 +171,7 @@ describe 'metatest' do
         }
 
         it { expect(result[0][0]).to include :failed }
-        it { expect(result[0][0][2]).to include "The program was expected to fail by <strong>out of board</strong>, but it failed by another reason." }
+        it { expect(result[0][0][3][:message]).to include "The program was expected to fail by <strong>out of board</strong>, but it failed by another reason." }
       end
 
     end
@@ -200,7 +200,7 @@ describe 'metatest' do
         let(:exit_status) { nil }
 
         it { expect(result[0][0]).to include :failed }
-        it { expect(result[0][0][2]).to include "<strong>29</strong> was expected but no value was obtained." }
+        it { expect(result[0][0][3][:message]).to include "<strong>29</strong> was expected but no value was obtained." }
       end
 
       context 'when fails by different values' do
@@ -214,7 +214,7 @@ describe 'metatest' do
         }
 
         it { expect(result[0][0]).to include :failed }
-        it { expect(result[0][0][2]).to include "<strong>11</strong> was expected but <strong>29</strong> was obtained." }
+        it { expect(result[0][0][3][:message]).to include "<strong>11</strong> was expected but <strong>29</strong> was obtained." }
       end
 
     end
@@ -224,7 +224,7 @@ describe 'metatest' do
 
       context 'when fails because the program did boom' do
         it { expect(result[0][0]).to include :failed }
-        it { expect(result[0][0][2]).to include "The program did BOOM." }
+        it { expect(result[0][0][3][:message]).to include "The program did BOOM." }
       end
     end
 


### PR DESCRIPTION
Removing board title. This change requires changes introduced in https://github.com/mumuki/mumuki-laboratory/pull/1399.

Although this PR is compatible with previous versions of laboratory, titles won't be displayed. 
