### PR TITLE
Green color  takes effect in kindergarten's repeat only

### DIFF
--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -124,7 +124,7 @@
           Blockly.CUSTOM_COLORS.complete = Blockly.MUMUKI_COLORS.pink;
 
           // control structures
-          Blockly.CUSTOM_COLORS.controlStructure = Blockly.MUMUKI_COLORS.green;
+          Blockly.CUSTOM_COLORS.controlStructure = this._isKindergarten() ? Blockly.MUMUKI_COLORS.green : Blockly.MUMUKI_COLORS.yellow;
 
           // commands
           Blockly.CUSTOM_COLORS.primitiveCommand = Blockly.MUMUKI_COLORS.yellow;


### PR DESCRIPTION
# :dart: Goal 

The goal of this PR is to allow using a different - experimental - kindergarten color without affecting backwards compatibility. 

# :back: Backward compatibility

This PR exist only for adding backward compatibility lost in #191 

# :camera_flash: 

## Primary

![image](https://user-images.githubusercontent.com/677436/92959723-b468b000-f442-11ea-96d0-a0452db79626.png)

## Kindergarten

![image](https://user-images.githubusercontent.com/677436/92959834-e67a1200-f442-11ea-929e-ac049da470f4.png)
