### PR TITLE
Feature use settings instead of layout for game-framework

### DIFF
--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -376,6 +376,15 @@
         return mumuki.exercise.layout === 'input_kindergarten';
       },
 
+      _isGame() {
+        if (mumuki.exercise.settings) {
+          return mumuki.exercise.settings.game_framwork;
+        } else {
+          // for backwards compatibility
+          return this._isKindergarten();
+        }
+      },
+
       _compilationMode() {
         return this._isKindergarten() ? compilationModes.gameFramework : compilationModes.classic;
       },

--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -386,7 +386,7 @@
       },
 
       _compilationMode() {
-        return this._isKindergarten() ? compilationModes.gameFramework : compilationModes.classic;
+        return this._isGame() ? compilationModes.gameFramework : compilationModes.classic;
       },
 
       _setInitialXml: function (blockly) {

--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -378,7 +378,7 @@
 
       _isGame() {
         if (mumuki.exercise.settings) {
-          return mumuki.exercise.settings.game_framwork;
+          return mumuki.exercise.settings.game_framework;
         } else {
           // for backwards compatibility
           return this._isKindergarten();


### PR DESCRIPTION
# :dart: Goal

To decouple game framework - which was designed as layout agnostic - activation from `kindergarten`. That way `primary` exercises and even text exercises will be able to use `game_framework`, and `kindergarten` exercises will not be forced to do that. 


# :eyes: See also

* Related to https://github.com/mumuki/mumuki-laboratory/pull/1467
* https://github.com/mumuki/mumuki-gobstones-runner/pull/195#issuecomment-690670114