### PR TITLE
Feature kindergarten boom

### DIFF
--- a/lib/game_framework/extra.gbs.erb
+++ b/lib/game_framework/extra.gbs.erb
@@ -73,6 +73,7 @@ procedure ShiftTo(dir) {
 
 procedure CheckCollision() {
   if (hayBolitas(Azul) && nroBolitas(Azul) mod 2 == 0) {
+    After();
     BOOM("Colision")
   }
 }

--- a/lib/render/editor/editor.css
+++ b/lib/render/editor/editor.css
@@ -115,3 +115,12 @@
     position: absolute;
   }
 }
+
+
+.mu-kids-exercise.mu-kindergarten .gbs_boom {
+  display: none;
+}
+
+.mu-kids-exercise.mu-kindergarten .mu-scenario.active table.gbs_board {
+  display: block !important;
+}

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -787,6 +787,29 @@ examples:
       expect(test_results response).to eq [{status: :passed, title: nil}]
     end
 
+    it 'answers a valid hash when submission is textual, collides and fails' do
+      response = bridge.run_tests!(
+        test: %q{
+examples:
+- initial_board: |
+    size 2 2
+    cell 0 0 Rojo 1
+    cell 1 0 Azul 2
+    head 0 0
+  final_board: |
+    size 2 2
+    cell 0 0 Verde 2
+    cell 1 0 Azul 2 Verde 2
+    cell 0 1 Rojo 1 Verde 2
+    cell 1 1 Verde 2},
+        extra: '',
+        content: 'procedure Main() { ShiftRight() }',
+        settings: {game_framework: true})
+      expect(response[:status]).to eq :failed
+      expect(response[:response_type]).to eq :structured
+      expect(test_results response).to eq [{status: :failed, title: nil, summary: {message: 'The program did BOOM.', type: 'check_failed_unexpected_boom'}}]
+    end
+
     it 'answers a valid hash when submission is block-based and passes' do
       response = bridge.run_tests!(
         test: %q{


### PR DESCRIPTION
# :dart: Goal

To always show board on kindergarten, even on `boom`, and allow content editors to represent boom situations using the gobstones attires mappings. 

# :memo: Details

I had to force style with an important since board hiding is being performed programatically by gobstones cli using an inline style :shrug:. 

Also, I had to change game framework to manually set overlay  right before `boom`. The downside is that won't allow showing an intermediate state of _i have just arrived to the obstacle, and I am about to collide_

# :warning: Warning

Rebase after #198

# :film_strip: Videos

This gif shows what happens when the `actor` :red_circle: passes through the `obstacle` `object` :two: :large_blue_circle: : program just stops - :two: :green_circle: - and no boom :boom: is displayed. 


![Peek 2020-09-18 09-53](https://user-images.githubusercontent.com/677436/93600296-c80d9c80-f995-11ea-9cf8-450d28b542c0.gif)


