### PR TITLE
Chore dont set toolbox when readonly

### DIFF
--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -122,11 +122,13 @@
        * have no sense to have a toolboxUrl.
        */
       configureCustomToolboxFromUrl(toolboxUrl) {
-        if (!this.readOnly) {
-          $.get(toolboxUrl, (toolboxXml) => {
-            this._initializeCustomToolboxBlocklyWorkspace(toolboxXml);
-          });
-        }
+        if (this.readOnly) return;
+
+        console.debug('Configuring custom toolbox');
+
+        $.get(toolboxUrl, (toolboxXml) => {
+          this._initializeCustomToolboxBlocklyWorkspace(toolboxXml);
+        });
       },
 
       /**
@@ -241,6 +243,8 @@
       },
 
       _initializeBlocklyWorkspace() {
+        console.debug('Initializing Blockly Workspace');
+
         this._setInitialXml();
         this._initializeWorkspace();
         this._subscribeToWorkspace(() => this._updateSolution());
@@ -977,13 +981,12 @@
       },
 
       _setEditorToolbox: function () {
-        const editor = $("mu-gobstones-custom-editor")[0];
+        const $editor = $("mu-gobstones-custom-editor")[0];
 
-        // editor may have not yet been loaded
-        // so there is nothing to do yet
-        if (!editor) return;
+        // there is no editor to configure
+        if (!$editor) return;
 
-        editor.configureCustomToolboxFromUrl(this.toolboxUrl);
+        $editor.configureCustomToolboxFromUrl(this.toolboxUrl);
       }
     });
   </script>

--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -121,6 +121,12 @@
         this._initializeBlocklyWorkspace();
       },
 
+      loadToolboxFromUrl(toolboxUrl) {
+        $.get(toolboxUrl, (toolboxXml) => {
+          this.setToolbox(toolboxXml);
+        });
+      },
+
       compile(code) {
         return this._compilationMode().compile(code);
       },
@@ -946,9 +952,7 @@
 
       _setEditorToolbox: function () {
         const editor = $("mu-gobstones-custom-editor")[0];
-        $.get(this.toolboxUrl, function (toolboxXml) {
-          editor.setToolbox(toolboxXml);
-        });
+        editor.loadToolboxFromUrl(this.toolboxUrl);
       }
     });
   </script>

--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -978,6 +978,11 @@
 
       _setEditorToolbox: function () {
         const editor = $("mu-gobstones-custom-editor")[0];
+
+        // editor may have not yet been loaded
+        // so there is nothing to do yet
+        if (!editor) return;
+
         editor.configureCustomToolboxFromUrl(this.toolboxUrl);
       }
     });

--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -115,16 +115,26 @@
         this._scrollToMainBlock();
       },
 
-      setToolbox(toolboxXml) {
-        this._getBlockly().toolbox = { defaultToolbox: toolboxXml };
-        // Blockly's workspace is destroyed when toolbox changes, so we initialize it here.
-        this._initializeBlocklyWorkspace();
+      /**
+       * Configures a custom toolbox using a toolbox url
+       * This method does nothing if editor is read-only, but
+       * assumes a gs-toolbox element is present - otherwise it would
+       * have no sense to have a toolboxUrl.
+       */
+      configureCustomToolboxFromUrl(toolboxUrl) {
+        if (!this.readOnly) {
+          $.get(toolboxUrl, (toolboxXml) => {
+            this._initializeCustomToolboxBlocklyWorkspace(toolboxXml);
+          });
+        }
       },
 
-      loadToolboxFromUrl(toolboxUrl) {
-        $.get(toolboxUrl, (toolboxXml) => {
-          this.setToolbox(toolboxXml);
-        });
+      /**
+       * Wether a custom toolbox is required. Read only editors and gs-toolbox-less context
+       * don't require it
+       */
+      hasCustomToolbox() {
+        return !this.readOnly && $('gs-toolbox').length;
       },
 
       compile(code) {
@@ -133,10 +143,6 @@
 
       hasInteractiveProgram() {
         return this._getBlockly().initialXml.indexOf("block type=\"InteractiveProgram\"") !== -1;
-      },
-
-      hasCustomToolbox() {
-        return $('gs-toolbox').length;
       },
 
       toggleInteractiveMode() {
@@ -197,12 +203,7 @@
       _configureBlocklyBehavior() {
         this._setTeacherActions();
         this._setGameActions();
-
-        // Blockly's workspace is destroyed when toolbox changes, so it doesn't make sense to initialize it here.
-        if (!this.hasCustomToolbox()) {
-          this._initializeBlocklyWorkspace();
-        }
-
+        this._initializeNonCustomToolboxBlocklyWorkspace();
         this._registerLayoutChangedEvent();
       },
 
@@ -212,6 +213,31 @@
         });
 
         $(window).resize(() => this._relocateTrash());
+      },
+
+
+      /**
+       * Initializes a workspace using a custom toolbox.
+       *
+       * Blockly's workspace is destroyed when toolbox changes, so initialization
+       * is performed here
+       */
+      _initializeCustomToolboxBlocklyWorkspace(toolboxXml) {
+        this._getBlockly().toolbox = { defaultToolbox: toolboxXml };
+        this._initializeBlocklyWorkspace();
+      },
+
+      /**
+       * Initializes a workspace using a non-custom toolbox.
+       *
+       * Blockly's workspace is destroyed when toolbox changes,
+       * so this method will initialize it only if a there is a custom toolbox
+       * that will be called later.
+       */
+      _initializeNonCustomToolboxBlocklyWorkspace() {
+        if (!this.hasCustomToolbox()) {
+          this._initializeBlocklyWorkspace();
+        }
       },
 
       _initializeBlocklyWorkspace() {
@@ -952,7 +978,7 @@
 
       _setEditorToolbox: function () {
         const editor = $("mu-gobstones-custom-editor")[0];
-        editor.loadToolboxFromUrl(this.toolboxUrl);
+        editor.configureCustomToolboxFromUrl(this.toolboxUrl);
       }
     });
   </script>


### PR DESCRIPTION
## :dart: Goal

This PR fixes miscellaneous classroom bugs related with toolbox initialization in read-only contexts

## :memo: Details

The main problem was that new code was not properly handling the `readOnly` flag, causing errors to arise and preventing workspace to be actually initialized. The main fix is to avoid setting a toolbox in read-only mode, but still allowing workspace to be initialized. The rest is refactoring

1. I have delegated into `configureCustomToolboxFromUrl` the async process of loading a toolbox
2. I have augmented `hasCustomToolbox` to only consider editable workspaces
3. I have extracted two very explicit methods for initializing workspace with and without a custom toolbox: `_initializeCustomToolboxBlocklyWorkspace` and `_initializeNonCustomToolboxBlocklyWorkspace`
4. As a side improvement, now toolboxes will not even been fetched in `readOnly` mode


This PR fixes the following classroom errors: 

#### `Uncaught Existing toolbox is null.  Can't create new toolbox.`

This is the original issue:

![Screenshot_2020-10-20_18-35-44](https://user-images.githubusercontent.com/677436/96646798-13073080-1303-11eb-977c-2580371de64b.png)

#### `Cannot read property 'configureCustomToolboxFromUrl' of undefined`

This bug is a consequence of fixing the latter. It looks like that in some contexts classroom tries to initialize the editor several times, but only one succeeds, and the rest fails. I am simply swallowing the failing scenario. 

![Screenshot_2020-10-20_18-32-12](https://user-images.githubusercontent.com/677436/96646537-a8ee8b80-1302-11eb-8b37-5d9143dab3b0.png)


## :camera: Screenshot

Finally - when used along https://github.com/mumuki/mumuki-classroom-ui/pull/284 - no errors and everything works: 

![Screenshot_2020-10-20_18-57-13](https://user-images.githubusercontent.com/677436/96648742-32ec2380-1306-11eb-9bae-fa41c855de29.png)
