### PR TITLE
Chore swallow tooltip errors

### DIFF
--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -5,6 +5,24 @@
 <script src="./hammer.min.js"></script>
 
 <script>
+  Blockly.FieldImage.prototype.__setValue__ = Blockly.FieldImage.prototype.setValue;
+  Blockly.FieldImage.prototype.setValue = function(a) {
+    if (a && a.startsWith("undefined")) {
+      console.debug(`Ignoring unavailable image ${a}`);
+    } else {
+      this.__setValue__(a);
+    }
+  }
+
+  Blockly.FieldImage.prototype.__setTooltip__ = Blockly.FieldImage.prototype.setTooltip;
+  Blockly.FieldImage.prototype.setTooltip = function(a) {
+    try {
+      this.__setTooltip__(a);
+    } catch (_e) {
+      console.debug('Could not set tooltip');
+    }
+  }
+
   function postpone(action) {
     return setTimeout(action, 50);
   }


### PR DESCRIPTION
# :gorilla: Goal

Ignore the nasty tooltip errors with some monkeypatching :monkey: .

# :camera_flash: Screenshots

> All the captures have been taken with `debug` (`verbose`) mode on

![Screenshot_2020-10-22_17-10-32](https://user-images.githubusercontent.com/677436/96924779-863aaf00-1489-11eb-92cb-ad2ecdb3da62.png)
![Screenshot_2020-10-22_17-10-22](https://user-images.githubusercontent.com/677436/96924788-88047280-1489-11eb-8484-bcc647f59f37.png)
![Screenshot_2020-10-22_17-10-12](https://user-images.githubusercontent.com/677436/96924824-96eb2500-1489-11eb-835b-b73bfa70fa15.png)


# :soon: Future work

We should instead PR this to `gs-element-blockly`


