### PR TITLE
Fix #213 trash does not appear on kindergarten

### DIFF
--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -248,6 +248,8 @@
        *
        * Blockly's workspace is destroyed when toolbox changes, so initialization
        * is performed here
+
+       * @see _initializeBlocklyWorkspace
        */
       _initializeCustomToolboxBlocklyWorkspace(toolboxXml) {
         this._getBlockly().toolbox = { defaultToolbox: toolboxXml };
@@ -260,6 +262,8 @@
        * Blockly's workspace is destroyed when toolbox changes,
        * so this method will initialize it only if a there is a custom toolbox
        * that will be called later.
+       *
+       * @see _initializeBlocklyWorkspace
        */
       _initializeNonCustomToolboxBlocklyWorkspace() {
         if (!this.hasCustomToolbox()) {
@@ -267,11 +271,20 @@
         }
       },
 
+      /**
+       * Performs actual workspace (re)creation,
+       * which sets initial xml, user solution, trash position
+       * and appropriate callbacks.
+       *
+       * This method is the actual culmination of the blockly initialization
+       * process
+       */
       _initializeBlocklyWorkspace() {
         console.debug('Initializing Blockly Workspace');
 
         this._setInitialXml();
         this._initializeWorkspace();
+        this._relocateTrash();
         this._subscribeToWorkspace(() => this._updateSolution());
 
         if (this.hasInteractiveProgram()) {

--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -287,10 +287,11 @@
           return;
         }
 
+        const $blocklyTrash = $('.blocklyTrash');
         const width = $('#blocklyDiv').width() - 68;
         const height = $('#blocklyDiv').height() - 210;
-        $('.blocklyTrash').css("transform", `translate(${width}px, ${height}px)`);
-        $('.blocklyTrash').css("display", "unset");
+        $blocklyTrash.css("transform", `translate(${width}px, ${height}px)`);
+        $blocklyTrash.css("display", "unset");
       },
 
       _updateSolution() {

--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -216,10 +216,7 @@
         this._setBlocklyDisplayMode();
         this._setBlocklySounds();
         this._setBlocklyColors();
-
-        if (!this.readOnly) {
-          this._relocateTrashOnResize();
-        }
+        this._relocateTrashOnResize();
 
         // Removing "/" from the block id character set to avoid syntax errors
         Blockly.utils.genUid.soup_ = Blockly.utils.genUid.soup_.replace("/", "");
@@ -233,6 +230,11 @@
       },
 
       _relocateTrashOnResize() {
+        if (this.readOnly) {
+          console.debug("No trash relocate on resize required");
+          return;
+        }
+
         $('.mu-kids-context, .mu-kids-results').on('hidden.bs.modal shown.bs.modal', () => {
           this._relocateTrash();
         });
@@ -280,6 +282,11 @@
       },
 
       _relocateTrash() {
+        if (this.readOnly) {
+          console.debug("No trash relocate required");
+          return;
+        }
+
         const width = $('#blocklyDiv').width() - 68;
         const height = $('#blocklyDiv').height() - 210;
         $('.blocklyTrash').css("transform", `translate(${width}px, ${height}px)`);


### PR DESCRIPTION
# :dart: Goal

To fix trash relocation errors

# :memo: Details

The problem was that a call to `_relocateTrash` after initializing the workspace was missing

# :camera_flash: Screenshots

## Kindergarten

![image](https://user-images.githubusercontent.com/677436/98848121-feb0e200-242f-11eb-90f8-0a8ee278db5a.png)
![Screenshot_2020-11-11_15-13-55](https://user-images.githubusercontent.com/677436/98848498-9282ae00-2430-11eb-9863-e27add0d4ec0.png)

## Primary

![image](https://user-images.githubusercontent.com/677436/98848167-112b1b80-2430-11eb-8d96-99ef3c1c665a.png)
![Screenshot_2020-11-11_15-12-49](https://user-images.githubusercontent.com/677436/98848502-93b3db00-2430-11eb-822e-56c8b5d36e40.png)

## Classroom

![image](https://user-images.githubusercontent.com/677436/98852297-3d499b00-2436-11eb-8af0-e77cc9e9feb3.png)

