### PR TITLE
Feature hide bubble on kindergarten

### DIFF
--- a/lib/render/editor/editor.css
+++ b/lib/render/editor/editor.css
@@ -133,3 +133,7 @@
     border: 1px solid #6D6E70 !important;
     border-radius: 4px;
 }
+
+.mu-exercise-content.gbs-game-framework .blocklyBubbleCanvas {
+  display: none;
+}

--- a/lib/render/editor/editor.css
+++ b/lib/render/editor/editor.css
@@ -134,6 +134,6 @@
     border-radius: 4px;
 }
 
-.mu-exercise-content.gbs-game-framework .blocklyBubbleCanvas {
+.mu-kids-exercise.mu-kindergarten .blocklyBubbleCanvas {
   display: none;
 }

--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -224,7 +224,6 @@
 
       _configureBlocklyBehavior() {
         this._setTeacherActions();
-        this._setGameLayout();
         this._setGameActions();
         this._initializeNonCustomToolboxBlocklyWorkspace();
         this._registerLayoutChangedEvent();
@@ -406,13 +405,6 @@
         $('#gbsPlayButton')[0].addEventListener('focus', function () {
           this.blur();
         })
-      },
-
-      _setGameLayout() {
-        if (this._isGame()) {
-          console.debug("Set game layout");
-          $(".mu-exercise-content").addClass('gbs-game-framework');
-        }
       },
 
       _setTeacherActions() {

--- a/lib/render/editor/editor.html.erb
+++ b/lib/render/editor/editor.html.erb
@@ -224,6 +224,7 @@
 
       _configureBlocklyBehavior() {
         this._setTeacherActions();
+        this._setGameLayout();
         this._setGameActions();
         this._initializeNonCustomToolboxBlocklyWorkspace();
         this._registerLayoutChangedEvent();
@@ -405,6 +406,13 @@
         $('#gbsPlayButton')[0].addEventListener('focus', function () {
           this.blur();
         })
+      },
+
+      _setGameLayout() {
+        if (this._isGame()) {
+          console.debug("Set game layout");
+          $(".mu-exercise-content").addClass('gbs-game-framework');
+        }
       },
 
       _setTeacherActions() {


### PR DESCRIPTION
# :dart: Goal

To hide bubble on kindergarten exercises, in order to reduce text prompts. 

# :memo: Details

This PR hides blockly bubble in kinder only. I initially thought about making this work for game framework, but it is not a problem style issue, but a layout issue.

# :camera: Screenshots

## Kindergarten

![image](https://user-images.githubusercontent.com/677436/100632962-382c8d00-330c-11eb-93c4-4b1235fa5dad.png)


## Primary

![image](https://user-images.githubusercontent.com/677436/100632935-2fd45200-330c-11eb-984b-af5bedf05a85.png)
